### PR TITLE
Converted to "through2" npm package from "through"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save node-shntool
 ## Code Examples
 
 This is the first release of this interface, it is currently experimental.
-It currently supports 'CUE file' generation and joining files.
+It currently supports 'CUE file' generation, joining files, and rudimentary format conversion.
 The first argument to the promise calls is a string or list of strings used by the 'globby' module to locate the input files.
 The second argument to the promise calls is any options for the function itself.
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function() {
         fs = require('fs-extra'),
         path = require('path'),
         globby = require('globby'),
-        through = require('through'),
+        through = require('through2'),
         util = require('util'),
         concat = require('concat-stream');
 
@@ -71,7 +71,7 @@ module.exports = function() {
         stream.on('error', callback);
 
         var curline = '';
-        function parseOutput(data){
+        function parseOutput(data, enc, cb){
             curline += data;
             var barelines = curline.split(/\r?\n/);
             curline = barelines.pop();
@@ -87,6 +87,7 @@ module.exports = function() {
                     return outfile.substr(1, outfile.length-2);
                 })));
             }
+            cb(null,data);
         }
         return stream;
     }
@@ -134,9 +135,10 @@ module.exports = function() {
         stream.on('end', callback);
         stream.on('error', callback);
 
-        function accumulateFile(data) {
+        function accumulateFile(data, enc, cb) {
             //console.log('accumulating');
             cuefile += data;
+            cb(null,data);
         }
         return stream;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-shntool",
-  "version": "0.2.0-alpha",
+  "version": "0.2.1",
   "description": "Node interface to shntool (http://www.etree.org/shnutils/shntool/)",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,6 @@
     "concat-stream": "^2.0.0",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
-    "through": "^2.3.8"
+    "through2": "^3.0.1"
   }
 }


### PR DESCRIPTION
Moving from older through() modules to through2() which supports callbacks and is currently maintained.